### PR TITLE
- added missing shortcut description for Lock (Cmd/Ctrl+L)

### DIFF
--- a/app/scripts/util/locale.js
+++ b/app/scripts/util/locale.js
@@ -278,6 +278,7 @@ var Locale = {
     setShOpen: 'open / new',
     setShSave: 'save all files',
     setShGen: 'generate password',
+    setShLock: 'lock database',
 
     setAboutTitle: 'About',
     setAboutBuilt: 'This app is built with these awesome tools',

--- a/app/templates/settings/settings-shortcuts.hbs
+++ b/app/templates/settings/settings-shortcuts.hbs
@@ -13,4 +13,5 @@
     <div><span class="shortcut">{{{cmd}}}O</span> {{res 'setShOpen'}}</div>
     <div><span class="shortcut">{{{cmd}}}S</span> {{res 'setShSave'}}</div>
     <div><span class="shortcut">{{{cmd}}}G</span> {{res 'setShGen'}}</div>
+    <div><span class="shortcut">{{{cmd}}}L</span> {{res 'setShLock'}}</div>
 </div>


### PR DESCRIPTION
- Shortcut for Lock is missing on settings page