### PR TITLE
updating to add apple meta tags

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <title>KeeWeb</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black">
     <link rel="shortcut icon" href="favicon.png?__inline=true" />
     <link rel="apple-touch-icon" sizes="192x192" href="touchicon.png?__inline=true">
     <link rel="stylesheet" href="css/main.css?__inline=true" />


### PR DESCRIPTION
I've been using the hosted keeweb application on iOS and decided to save it to my home screen. Figured it would be a useful patch to remove the safari navigation bars, and make the home screen bookmark work like a standalone app.