### PR TITLE
Textarea color as input color.  Fixes #187

### DIFF
--- a/app/styles/base/_forms.scss
+++ b/app/styles/base/_forms.scss
@@ -90,6 +90,7 @@ input[type=text], input[type=password], textarea, input:not([type]) {
 
 textarea {
   resize: vertical;
+  color: inherit;
 }
 
 input[type="search"] {


### PR DESCRIPTION
Fixes #187 (Textarea text color is always black, even in dark themes.)

This seems like a bug to me, but I understand you have some opinions about the colors. 
Please do disregard this if it's not what you want.

Thanks anyway for your time,
Victor
